### PR TITLE
scriptタグの位置をbody末尾に移動。

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,6 @@
 <head>
   <title>StartDash</title>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
 </head>
 <body>
@@ -12,5 +11,7 @@
   <div class="container container-main">
     <%= yield %>
   </div>
+  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%= yield :script %>
 </body>
 </html>


### PR DESCRIPTION
scriptタグをhead内に置くと、ページのロードが遅延するため、body末尾に置くか、async属性を付けるなどしたほうが良いです。

async属性は、スクリプトの読み込み順序に依存関係がある場合に問題が出る場合があるため、末尾に記述してみました。
それだけだと、viewの中にjQuery等に依存するスクリプトを埋め込めなくなるので、埋め込む用の yieldをレイアウトに追加しました。

参考) http://memocarilog.info/jquery/5842
